### PR TITLE
Add environment variable for plugins

### DIFF
--- a/configure-db.php
+++ b/configure-db.php
@@ -102,7 +102,7 @@ catch (PDOException $e) {
 
 $contents = file_get_contents($confpath);
 if(getenv('AUTH_METHOD') == "ldap") {
-    $config['PLUGINS'] = 'auth_ldap, note';
+    $config['PLUGINS'] = 'auth_ldap, note, ' . env("PLUGINS", "");
     $contents .= "define('LDAP_AUTH_SERVER_URI', '" . env("LDAP_AUTH_SERVER_URI", "ldap://ldap") . "');\n";
     $contents .= "define('LDAP_AUTH_USETLS', " . env("LDAP_AUTH_USETLS", "FALSE") . "); \n";
     $contents .= "define('LDAP_AUTH_ALLOW_UNTRUSTED_CERT', " . env("LDAP_AUTH_ALLOW_UNTRUSTED_CERT", "TRUE") . ");\n";

--- a/configure-db.php
+++ b/configure-db.php
@@ -102,7 +102,10 @@ catch (PDOException $e) {
 
 $contents = file_get_contents($confpath);
 if(getenv('AUTH_METHOD') == "ldap") {
-    $config['PLUGINS'] = 'auth_ldap, note, ' . env("PLUGINS", "");
+    $config['PLUGINS'] = 'auth_ldap, note';
+    if(getenv('PLUGINS')!=""){
+        $config['PLUGINS'] .= ', ' . env("PLUGINS", "");
+    }
     $contents .= "define('LDAP_AUTH_SERVER_URI', '" . env("LDAP_AUTH_SERVER_URI", "ldap://ldap") . "');\n";
     $contents .= "define('LDAP_AUTH_USETLS', " . env("LDAP_AUTH_USETLS", "FALSE") . "); \n";
     $contents .= "define('LDAP_AUTH_ALLOW_UNTRUSTED_CERT', " . env("LDAP_AUTH_ALLOW_UNTRUSTED_CERT", "TRUE") . ");\n";


### PR DESCRIPTION
Sometimes it seems to be useful to enable plugins systemwide. Like I wanted to use ttrss using feedreader which is relying on the api_feedreader plugin that can't be activated by user.
This PR adds an environment variable "PLUGINS" allowing to add plugins to the config. 