### PR TITLE
Update to Ubuntu 16.04/Plp 7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Christian Lück <christian@lueck.tv>
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
-  git nginx supervisor php5-fpm php5-cli php5-curl php5-gd php5-json \
-  php5-pgsql php5-ldap php5-mysql php5-mcrypt && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y php7.0-mbstring \
+  git nginx supervisor php7.0-fpm php7.0-cli php7.0-curl php7.0-gd php7.0-json php-gettext php7.0-intl \
+  php7.0-pgsql php7.0-ldap php7.0-mysql php7.0-mcrypt && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # enable the mcrypt module
-RUN php5enmod mcrypt
+RUN phpenmod mcrypt
 
 # add ttrss as the only nginx site
 ADD ttrss.nginx.conf /etc/nginx/sites-available/ttrss
@@ -20,10 +20,15 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl --n
     && apt-get purge -y --auto-remove curl \
     && chown www-data:www-data -R /var/www
 
-RUN git clone https://github.com/hydrian/TTRSS-Auth-LDAP.git /TTRSS-Auth-LDAP && \
-    cp -r /TTRSS-Auth-LDAP/plugins/auth_ldap plugins/ && \
-    ls -la /var/www/plugins
-RUN cp config.php-dist config.php
+ADD af_newspapers /var/www/plugins/af_newspapers
+
+RUN git clone https://github.com/hydrian/TTRSS-Auth-LDAP.git /TTRSS-Auth-LDAP \
+    && cp -r /TTRSS-Auth-LDAP/plugins/auth_ldap plugins/ \
+    && git clone https://github.com/HenryQW/mercury_fulltext.git /var/www/plugins/mercury_fulltext \
+    && ls -la /var/www/plugins
+
+RUN cp config.php-dist config.php \
+    && mkdir -p /var/run/php
 
 # expose only nginx HTTP port
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl --n
 
 ADD af_newspapers /var/www/plugins/af_newspapers
 
-RUN git clone https://github.com/hydrian/TTRSS-Auth-LDAP.git /TTRSS-Auth-LDAP \
-    && cp -r /TTRSS-Auth-LDAP/plugins/auth_ldap plugins/ \
+RUN git clone https://github.com/hydrian/TTRSS-Auth-LDAP.git /root/TTRSS-Auth-LDAP \
+    && cp -r /root/TTRSS-Auth-LDAP/plugins/auth_ldap plugins/ \
+    && rm -rf /root/TTRSS-Auth-LDAP \
     && git clone https://github.com/HenryQW/mercury_fulltext.git /var/www/plugins/mercury_fulltext \
     && ls -la /var/www/plugins
 

--- a/af_newspapers/init.php
+++ b/af_newspapers/init.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * af_newspapers/init.php
+ * Plugin for TT-RSS 1.7.9
+ *
+ * Retrieves full article text for feeds from Movable Type Enterprise sites (commonly
+ * used by newspapers).
+ *
+ * CHANGELOG:
+ * Version 1.2 by craywolf 2013-04-19 @ 14:00 GMT
+ * 	- Added api_version() call
+ * 	- Removed cruft
+ * Version 1.1 by craywolf 2013-04-17 @ 15:22 GMT
+ * 	- Added fix for removal of $this->link in 1.7.9
+ * 	- Added "more info" link to about()
+ * Version 1.0 by craywolf 2013-03-26 @ 16:17 GMT
+ * 	- Initial release
+ */
+class Af_newspapers extends Plugin {
+	private $host;
+
+	function about() {
+		return array(1.2,
+			"Turn newspaper feeds using Movable Type Enterprise (index.ssf in story link) into full-story feeds",
+			"craywolf",
+			"",
+			"http://tt-rss.org/forum/viewtopic.php?f=22&t=1539");
+	}
+
+	function api_version() {
+		return 2;
+	}
+
+	function init($host) {
+		$this->host = $host;
+
+		$host->add_hook($host::HOOK_ARTICLE_FILTER, $this);
+	}
+
+	function hook_article_filter($article) {
+		$owner_uid = $article["owner_uid"];
+
+		if (strpos($article["link"], "/index.ssf/") !== FALSE) {
+			if (strpos($article["plugin_data"], "newspapers-full,$owner_uid:") === FALSE) {
+
+				$doc = new DOMDocument();
+				@$doc->loadHTML(fetch_file_contents($article["link"]));
+
+				$basenode = false;
+
+				if ($doc) {
+					$xpath = new DOMXPath($doc);
+					
+					$entries = $xpath->query('(//div[@class="entry-content"])');
+					foreach ($entries as $entry) {
+						$basenode = $entry;
+					}
+
+					if ($basenode) {
+						$article["content"] = $doc->saveXML($basenode); //, LIBXML_NOEMPTYTAG);
+						$article["plugin_data"] = "newspapers-full,$owner_uid:" . $article["plugin_data"];
+					}
+				}
+			} else if (isset($article["stored"]["content"])) {
+				$article["content"] = $article["stored"]["content"];
+			}
+		}
+
+		return $article;
+	}
+}
+?>

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,8 +1,8 @@
 [supervisord]
 nodaemon=true
 
-[program:php5-fpm]
-command=/usr/sbin/php5-fpm --nodaemonize
+[program:php-fpm7.0]
+command=/usr/sbin/php-fpm7.0 --nodaemonize
 
 [program:nginx]
 command=/usr/sbin/nginx -g "daemon off;"

--- a/ttrss.nginx.conf
+++ b/ttrss.nginx.conf
@@ -10,8 +10,8 @@ server {
 
 	location ~ \.php$ {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
-		fastcgi_pass unix:/var/run/php5-fpm.sock;
+		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
 		fastcgi_index index.php;
-		include fastcgi_params;
+		include fastcgi.conf;
 	}
 }


### PR DESCRIPTION
The current version of tt-rss requires at least Php 5.6.0, however the maximum version available from the standard Ubuntu 14.04 repositories is Php 5.5.9 and in any event Ubuntu 14.04 is now end of life.  Moving to Ubuntu 16.04 and Php 7.0 seems the best option but requires some other changes.  I have also added some more full text plugins to deal with sites that don't work so well with af_readability.