### PR TITLE
Fix ttrss archive URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,12 @@ ADD ttrss.nginx.conf /etc/nginx/sites-available/ttrss
 RUN ln -s /etc/nginx/sites-available/ttrss /etc/nginx/sites-enabled/ttrss
 RUN rm /etc/nginx/sites-enabled/default
 
+ARG TTRSS_VERSION=7e2fd9bdce4a0ff05e7c76aee52e30c26d5b2093
+
 # install ttrss and patch configuration
 WORKDIR /var/www
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl --no-install-recommends && rm -rf /var/lib/apt/lists/* \
-    && curl -SL https://git.tt-rss.org/fox/tt-rss/archive/19.2.tar.gz | tar xzC /var/www --strip-components 1 \
+    && curl -SL https://git.tt-rss.org/fox/tt-rss/archive/${TTRSS_VERSION}.tar.gz | tar xzC /var/www --strip-components 1 \
     && apt-get purge -y --auto-remove curl \
     && chown www-data:www-data -R /var/www
 


### PR DESCRIPTION
Version 19.2 doesn't seem to exist anymore. Moreover the latest tag is
6 years old and the installation instruction recommends to ignore the
releases page (https://git.tt-rss.org/fox/tt-rss/wiki/InstallationNotes#host-installation-overview).
Using commit hash to pin version and prevent unattended updates.